### PR TITLE
Make it possible to brew install this provider

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,6 +24,7 @@ build:
       - dist/*.tar.gz
       - dist/*.zip
       - dist/*.txt
+      - dist/*.rb
       - terraform-provider-conjur  # for next stage
 
 test:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,5 +27,30 @@ archive:
 checksum:
   name_template: 'SHA256SUMS.txt'
 
+brew:
+  description: Terraform provider for CyberArk Conjur
+  homepage: https://github.com/cyberark/terraform-provider-conjur
+  url_template: https://github.com/cyberark/terraform-provider-conjur/releases/download/v{{.Version}}/terraform-provider-conjur-darwin-amd64.tar.gz
+  caveats: |
+    After installation, you must symlink the provider into Terraform's plugins directory.
+
+    mkdir -p ~/.terraform.d/plugins/
+    ln -sf /usr/local/Cellar/terraform-provider-conjur/<VERSION>/bin/terraform-provider-conjur ~/.terraform.d/plugins/terraform-provider-conjur
+
+    Symlinking is necessary because Homebrew is sandboxed and cannot write to your home directory.
+    Replace <VERSION> above.
+    If Homebrew is installing somewhere other than /usr/local/Cellar, update the path as well.
+  dependencies:
+    - terraform
+  install: |
+    bin.install "terraform-provider-conjur"
+  test: |
+    system "#{bin}/terraform-provider-conjur", "-h"  # running bin directly gives error, exit code 1
+
+  github:
+    owner: cyberark
+    name: homebrew-tools
+  skip_upload: true
+
 release:
   disable: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,10 +35,10 @@ brew:
     After installation, you must symlink the provider into Terraform's plugins directory.
 
     mkdir -p ~/.terraform.d/plugins/
-    ln -sf /usr/local/Cellar/terraform-provider-conjur/<VERSION>/bin/terraform-provider-conjur ~/.terraform.d/plugins/terraform-provider-conjur
+    ln -sf /usr/local/Cellar/terraform-provider-conjur/$VERSION/bin/terraform-provider-conjur ~/.terraform.d/plugins/terraform-provider-conjur
 
     Symlinking is necessary because Homebrew is sandboxed and cannot write to your home directory.
-    Replace <VERSION> above.
+    Replace $VERSION above.
     If Homebrew is installing somewhere other than /usr/local/Cellar, update the path as well.
   dependencies:
     - terraform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v0.2.0](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.2.0) - 2018-08-29
+### Added
+- Homebrew installer, see [TODO LINK] for instructions.
+
 ## [v0.1.0](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.1.0) - 2018-08-28
 ### Added
 - Initial release

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     stage('Build artifacts') {
       steps {
         sh './bin/build'
-        archiveArtifacts artifacts: "dist/*.tar.gz,dist/*.zip,dist/*.txt", fingerprint: true
+        archiveArtifacts artifacts: "dist/*.tar.gz,dist/*.zip,dist/*.txt,dist/*.rb", fingerprint: true
       }
     }
     stage('Run integration tests (OSS)') {

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ The packages are available for Linux, macOS and Windows.
 Download and uncompress the latest release for your OS. This example uses the linux binary.
 
 ```sh-session
-$ wget https://github.com/cyberark/terraform-provider-conjur/releases/download/<VERSION>/terraform-provider-conjur-linux-amd64.tar.gz
+$ wget https://github.com/cyberark/terraform-provider-conjur/releases/download/$VERSION/terraform-provider-conjur-linux-amd64.tar.gz
 $ tar -xvf terraform-provider-conjur*.tar.gz
 ```
 
-Replace `<VERSION>` above.
+Replace `$VERSION` above.
 
 Now copy the binary to the Terraform's plugins folder. If this is your first plugin, you'll need to create the folder first.
 
@@ -46,12 +46,12 @@ Install the provider and symlink it to Terraform's plugins directory.
 $ brew install terraform-provider-conjur
 
 $ mkdir -p ~/.terraform.d/plugins/
-$ ln -sf /usr/local/Cellar/terraform-provider-conjur/<VERSION>/bin/terraform-provider-conjur
+$ ln -sf /usr/local/Cellar/terraform-provider-conjur/$VERSION/bin/terraform-provider-conjur
 ```
 
 Symlinking is necessary because
 [Homebrew is sandboxed and cannot write to your home directory](https://github.com/Homebrew/brew/issues/2986).
-Replace `<VERSION>` above.
+Replace `$VERSION` above.
 If Homebrew is installing somewhere other than `/usr/local/Cellar`, update the path as well.
 
 ### Compile from Source

--- a/README.md
+++ b/README.md
@@ -32,7 +32,25 @@ $ mv terraform-provider-conjur*/terraform-provider-conjur ~/.terraform.d/plugins
 
 ### Homebrew (MacOS)
 
-[coming soon...](https://github.com/cyberark/terraform-provider-conjur/issues/3)
+Add and update the CyberArk Tools Homebrew tap.
+
+```sh-session
+$ brew tap cyberark/tools
+```
+
+Install the provider and symlink it to Terraform's plugins directory.
+
+```sh-session
+$ brew install terraform-provider-conjur
+
+$ mkdir -p ~/.terraform.d/plugins/
+$ ln -sf /usr/local/Cellar/terraform-provider-conjur/<VERSION>/bin/terraform-provider-conjur
+```
+
+Symlinking is necessary because
+[Homebrew is sandboxed and cannot write to your home directory](https://github.com/Homebrew/brew/issues/2986).
+Replace `<VERSION>` above.
+If Homebrew is installing somewhere other than `/usr/local/Cellar`, update the path as well.
 
 ### Compile from Source
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ The packages are available for Linux, macOS and Windows.
 Download and uncompress the latest release for your OS. This example uses the linux binary.
 
 ```sh-session
-$ wget https://github.com/cyberark/terraform-provider-conjur/releases/download/v0.1.0/terraform-provider-conjur-linux-amd64.tar.gz
+$ wget https://github.com/cyberark/terraform-provider-conjur/releases/download/<VERSION>/terraform-provider-conjur-linux-amd64.tar.gz
 $ tar -xvf terraform-provider-conjur*.tar.gz
 ```
+
+Replace `<VERSION>` above.
 
 Now copy the binary to the Terraform's plugins folder. If this is your first plugin, you'll need to create the folder first.
 

--- a/bin/build
+++ b/bin/build
@@ -7,7 +7,7 @@ docker-compose pull goreleaser
 echo "> Building and packaging binaries"
 docker-compose run --rm -T --entrypoint sh goreleaser -es <<EOF
 dep ensure -v
-goreleaser release --rm-dist --skip-validate --snapshot
+goreleaser release --rm-dist --skip-validate
 EOF
 
 bin_name='terraform-provider-conjur'


### PR DESCRIPTION
Closes #3.

I would prefer to not have to ask the user to create the terraform plugins dir and symlink the provider in, but Homebrew uses a sandbox where you can't write to the user's home dir and [it doesn't look like they're gonna change that](https://github.com/Homebrew/brew/issues/2986). So, the README and brew caveats both instruct the user to do this. Once the provider is symlinked into `~/.terraform.d/plugins/`, Terraform will pick it up automatically when it runs.

After merge, I'll cut a 0.2.0 release w/ changelog for this homebrew recipe. This will give us a chance to use the CI-generated artifacts for github releases and homebrew, which is what we want. No hand-edited files as artifacts!!! :)

Please squash/merge.