### PR TITLE
Broken build is fixed for enterprise

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -85,7 +85,7 @@ function configureConjur() {
   dockerCompose up -d client
 
   if [[ "$TARGET" == "enterprise" ]]; then
-    clientExec conjur authn login -u admin -p secret
+    clientExec conjur authn login -u admin -p SEcret12!!!!
   fi
 
   # policy files are mounted in docker-compose


### PR DESCRIPTION
Integration tests are currently failing for the enterprise scenario.
The failure mode is that the test container can't authenticate with
the Conjur appliance test container. Root cause is that baked-in
password for testing was changed.

Fixes Community Integrations Issue #35