### PR TITLE
Prepare for v0.3.1 release by updating changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.3.1] - 2020-04-20
+### Fixed
+- Each brew recipe binary now includes the provider version [#47](https://github.com/cyberark/terraform-provider-conjur/issues/47)
+- Updated output binary file names to include version suffix so that the
+  version command returns the correct version [#30](https://github.com/cyberark/terraform-provider-conjur/issues/30)
+
 ## [0.3.0] - 2020-04-13
 ### Changed
 - Converted to Go modules
@@ -21,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Initial release
 - Use https://github.com/cyberark/conjur-api-go to read configuration.
 
-[Unreleased]: https://github.com/cyberark/terraform-provider-conjur/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/cyberark/terraform-provider-conjur/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/cyberark/terraform-provider-conjur/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/cyberark/terraform-provider-conjur/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/cyberark/terraform-provider-conjur/compare/v0.1.0...v0.2.0


### PR DESCRIPTION
Since we have new artifacts and new way to install the plugin, we need a
new release made (v0.3.1)