### PR TITLE
Prepare for v0.4.0 release by updating the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.0] - 2020-04-29
 ### Added
 - You can now specify `account`, `appliance_url`, `ssl_cert`, and `ssl_cert_path` values
   directly in the `.tf` provider config [#29](https://github.com/cyberark/terraform-provider-conjur/issues/29)
@@ -30,7 +32,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Initial release
 - Use https://github.com/cyberark/conjur-api-go to read configuration.
 
-[Unreleased]: https://github.com/cyberark/terraform-provider-conjur/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/cyberark/terraform-provider-conjur/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/cyberark/terraform-provider-conjur/compare/v0.3.0...v0.4.0
 [0.3.1]: https://github.com/cyberark/terraform-provider-conjur/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/cyberark/terraform-provider-conjur/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/cyberark/terraform-provider-conjur/compare/v0.1.0...v0.2.0


### PR DESCRIPTION
The new feature additions are big enough to warrant a new release.