### PR TITLE
Change brews.github to brews.tap

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,6 @@
 name: Integration Tests
 on:
-  # Only run this on pushes to master
+  # Run this on pushes to master
   push:
     branches:
     - master
@@ -11,6 +11,10 @@ on:
     - opened
     - reopened
     - synchronize
+
+  # And once daily at 12 AM UTC, 8 PM EST
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   test:
@@ -28,7 +32,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set VERSION
-      run: echo "::set-env name=VERSION::$(cat VERSION)"
+      run: echo "VERSION=$(cat VERSION)" >> $GITHUB_ENV
 
     - name: Build plugin (statically)
       run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,7 +53,7 @@ brews:
       # Running bin directly gives error, exit code 1
       system "#{bin}/terraform-provider-conjur_v{{.Version}}", "-h"
 
-    github:
+    tap:
       owner: cyberark
       name: homebrew-tools
     skip_upload: true


### PR DESCRIPTION
### What does this PR do?
- Support for brews.github was removed in v0.152.0: https://goreleaser.com/deprecations/#brewsgithub
- Also updates broken gh action, and sets it to run nightly

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation