### PR TITLE
Update docker-compose calls to not hang

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -6,11 +6,8 @@ docker-compose pull goreleaser
 
 echo "> Building and packaging binaries"
 docker-compose run --rm \
-  -T \
-  --entrypoint sh \
-  goreleaser -es << EOF
-    goreleaser release --rm-dist --skip-validate
-EOF
+  --entrypoint goreleaser \
+  goreleaser release --rm-dist --skip-validate
 
 # Needed for testing stages
 goos='linux'  # uname -s | tr '[:upper:]' '[:lower:]'

--- a/bin/test
+++ b/bin/test
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -exo pipefail
 
 TARGET="${1:-oss}"  # can also be set to 'enterprise'
 
@@ -73,7 +73,6 @@ function launchConjur() {
 
   echo ">> Starting Conjur/DAP server"
   dockerCompose up -d conjur-server
-
   echo ">> Creating account '$CONJUR_ACCOUNT'"
   if [[ "$TARGET" == "enterprise" ]]; then
     conjurExec evoke configure master \
@@ -152,11 +151,10 @@ function runTerraform() {
 
   dockerCompose up -d terraform
 
-  terraformRun <<EOF
-    terraform init $target_dir/
-    terraform plan $target_dir/
-    terraform apply -auto-approve $target_dir/
-EOF
+  terraformRun \
+    "terraform init $target_dir/ &&
+     terraform plan $target_dir/ &&
+     terraform apply -auto-approve $target_dir/"
 
   docker-compose rm --force \
     --stop \

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -19,5 +19,5 @@ function clientExec() {
 }
 
 function terraformRun() {
-  dockerCompose exec -T terraform sh -es "$@"
+  dockerCompose exec -T terraform sh -ec "$@"
 }


### PR DESCRIPTION
### What does this PR do?
Use of sh -es and heredocs causes docker-compose to hang.  It
explicitly sets up input/output that breaks with the newer
versions and unaffected versions are no longer available.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation