### PR TITLE
Adding the new Apple hardware platform

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,17 @@ builds:
   - amd64
   ldflags: []
 
+# Apple silicon support
+- id: summon-conjur-arm
+  binary: summon-conjur
+  env:
+  - CGO_ENABLED=0
+  goos:
+  - darwin  # MacOS
+  goarch:
+  - arm64
+  ldflags: []
+
 archives:
   - id: conjur-terraform-release-archive
     name_template: "{{.ProjectName}}-{{.Version}}-{{.Os}}-{{.Arch}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Build for Apple M1 silicon.
+  [cyberark/terraform-provider-conjur#84](https://github.com/cyberark/terraform-provider-conjur/issues/84)
+
 ## [0.5.0] - 2021-05-06
 ### Added
 - Validated support with Terraform v0.15. Please note that in v0.15, behavior


### PR DESCRIPTION
### What does this PR do?
As reported in [Homebrew tools](https://github.com/cyberark/homebrew-tools/issues/30)
Apple silicon is not supported.

GoReleaser should build an Apple M1

Testing:
kumbirai@Kumbirais-MacBook-Pro Downloads % file ./terraform-provider-conjur-0.5.0-darwin-arm64/summon-conjur
./terraform-provider-conjur-0.5.0-darwin-arm64/summon-conjur: Mach-O 64-bit executable arm64
kumbirai@Kumbirais-MacBook-Pro Downloads % ./terraform-provider-conjur-0.5.0-darwin-arm64/summon-conjur 
This binary is a plugin. These are not meant to be executed directly.
Please execute the program that consumes these plugins, which will
load any plugins automatically

### What ticket does this PR close?
Resolves #84

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x The changes in this PR do not require tests

#### Documentation
- [] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation