### PR TITLE
Update dev environment to work on CyberArk NG laptops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ vendor/
 dist/
 test/dbpass
 
+# Temporary directory to store the CyberArk proxy CA certificate.
+build_ca_certificate/
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,12 @@
+FROM goreleaser/goreleaser
+
+# On CyberArk dev laptops, golang dependencies are downloaded
+# with a corporate proxy in the middle. For these connections to
+# succeed we need to configure the proxy CA certificate in the
+# build container.
+#
+# To also allow this script to work on non-CyberArk laptops
+# we copy the certificate into the Docker image as a (potentially
+# empty) directory, rather than rely on the CA file itself.
+ADD build_ca_certificate /usr/local/share/ca-certificates/
+RUN update-ca-certificates

--- a/bin/build
+++ b/bin/build
@@ -1,15 +1,52 @@
 #!/bin/bash -e
 
-git fetch --tags  # jenkins does not do this automatically yet
+main() {
+  retrieve_cyberark_ca_cert
+  build_and_package_binaries
+}
 
-docker-compose pull goreleaser
+retrieve_cyberark_ca_cert() {
+  # On CyberArk dev laptops, golang dependencies are downloaded
+  # with a corporate proxy in the middle. For these connections
+  # succeed we need to configure the proxy CA certificate in the
+  # build container.
+  #
+  # To also allow this script to work on non-CyberArk laptops
+  # we copy the certificate into the Docker image as a (potentially
+  # empty) directory, rather than rely on the CA file itself.
+  mkdir -p "$(repo_root)/build_ca_certificate"
 
-echo "> Building and packaging binaries"
-docker-compose run --rm \
-  --entrypoint goreleaser \
-  goreleaser release --rm-dist --skip-validate
+  # Only attempt to extract the certificate if the security
+  # command is available.
+  #
+  # The certificate file must have the .crt extension to be imported
+  # by `update-ca-certificates`.
+  if command -v security &> /dev/null
+  then
+    security find-certificate \
+      -a -c "CyberArk Enterprise Root CA" \
+      -p > build_ca_certificate/cyberark_root.crt
+  fi
+}
 
-# Needed for testing stages
-goos='linux'  # uname -s | tr '[:upper:]' '[:lower:]'
-goarch="amd64"
-cp dist/terraform-provider-conjur_${goos}_${goarch}/terraform-provider-conjur_v* .
+build_and_package_binaries() {
+  git fetch --tags  # jenkins does not do this automatically yet
+
+  docker-compose build goreleaser
+
+  echo "> Building and packaging binaries"
+  docker-compose run --rm \
+    --entrypoint goreleaser \
+    goreleaser release --rm-dist --skip-validate
+
+  # Needed for testing stages
+  goos='linux'  # uname -s | tr '[:upper:]' '[:lower:]'
+  goarch="amd64"
+  cp dist/terraform-provider-conjur_${goos}_${goarch}/terraform-provider-conjur_v* .
+}
+
+repo_root() {
+  git rev-parse --show-toplevel
+}
+
+main

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,9 @@ services:
       - $PWD/dist/terraform-provider-conjur_linux_amd64/:/usr/share/terraform/plugins/terraform.example.com/cyberark/conjur/${CONJUR_PLUGIN_VERSION}/linux_amd64/
 
   goreleaser:
-    image: goreleaser/goreleaser:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.goreleaser
     volumes:
       - .:/terraform-provider-conjur
     working_dir: /terraform-provider-conjur


### PR DESCRIPTION
### What does this PR do?

On CyberArk dev laptops, the goreleaser (called by bin/build) is run with a corporate proxy between the laptop and the external internet. For dependency downloads to succeed we need to configure the proxy CA certificate in the goreleaser container.

### What ticket does this PR close?

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation