### PR TITLE
Fixes for GoReleaser v1.8.x

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -10,3 +10,6 @@ FROM goreleaser/goreleaser
 # empty) directory, rather than rely on the CA file itself.
 ADD build_ca_certificate /usr/local/share/ca-certificates/
 RUN update-ca-certificates
+
+# Workaround for CVE-2022-24765 when running git inside a docker container
+RUN git config --global --add safe.directory /terraform-provider-conjur

--- a/bin/build
+++ b/bin/build
@@ -42,7 +42,7 @@ build_and_package_binaries() {
   # Needed for testing stages
   goos='linux'  # uname -s | tr '[:upper:]' '[:lower:]'
   goarch="amd64"
-  cp dist/terraform-provider-conjur_${goos}_${goarch}/terraform-provider-conjur_v* .
+  cp dist/terraform-provider-conjur_${goos}_${goarch}_v1/terraform-provider-conjur_v* .
 }
 
 repo_root() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     working_dir: /src
     volumes:
       - $PWD:/src
-      - $PWD/dist/terraform-provider-conjur_linux_amd64/:/usr/share/terraform/plugins/terraform.example.com/cyberark/conjur/${CONJUR_PLUGIN_VERSION}/linux_amd64/
+      - $PWD/dist/terraform-provider-conjur_linux_amd64_v1/:/usr/share/terraform/plugins/terraform.example.com/cyberark/conjur/${CONJUR_PLUGIN_VERSION}/linux_amd64/
 
   goreleaser:
     build:


### PR DESCRIPTION
Jenkins build was failing because running GoReleaser resulted in:
```
⨯ release failed after 0.00s error=current folder is not a git repository
```

Enabling GoReleaser's debug logging revealed the following logs:
```
    • getting and validating git state
       • running git               args=[-c log.showSignature=false rev-parse --is-inside-work-tree]
       • git result                stderr=fatal: unsafe repository ('/summon-aws-secrets' is owned by someone else)
To add an exception for this directory, call:

      git config --global --add safe.directory /summon-aws-secrets
 stdout=
```

This is a symptom of recent git versions (>v2.35.2) offering security fixes for CVE-2022-24765 for git on multi-user machines, include Docker containers, included in the latest versions of GoReleaser.

### Implemented Changes

- `docker-compose.yml` mounts binary from updated directory
- `build` script copies binary from updated directory
- Apply workaround for CVE-2022-24765, calling `git config --global --add safe.directory /terraform-provider-conjur` in `Dockerfile.goreleaser`

### Connected Issue/Story

CyberArk internal issue link: [ONYX-19910](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-19910)

### Definition of Done

- [x] Fix `cyberark/terraform-provider-conjur` failing CI build

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
