### PR TITLE
Update to Go 1.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Security
+- Upgraded to Go 1.19 [cyberark/terraform-provider-conjur#110](https://github.com/cyberark/terraform-provider-conjur/pull/110)
 - Forced golang.org/x/net to use v0.0.0-20220923203811-8be639271d50 to resolve CVE-2022-27664
   [cyberark/terraform-provider-conjur#109](https://github.com/cyberark/terraform-provider-conjur/pull/109)
 

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-go 1.17
+go 1.19
 
 // Security fixes to ensure we don't have old vulnerable packages in our
 // dependency tree. We're often not vulnerable, but removing them to ensure


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome

Upgrade to Go 1.19 to ensure we have the fixed version of golang.org/x/net for CVE-2022-27664

### Implemented Changes

- Changed go.mod specified version
