### PR TITLE
Add replaces for golang.org/x/crypto & yaml.v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Security
+- Added replaces for 2 versions of golang.org/x/crypto brought in by the terraform sdk to resolve CVE-2021-43565
+  [cyberark/terraform-provider-conjur#111](https://github.com/cyberark/terraform-provider-conjur/pull/111)
 - Upgraded to Go 1.19 [cyberark/terraform-provider-conjur#110](https://github.com/cyberark/terraform-provider-conjur/pull/110)
 - Forced golang.org/x/net to use v0.0.0-20220923203811-8be639271d50 to resolve CVE-2022-27664
   [cyberark/terraform-provider-conjur#109](https://github.com/cyberark/terraform-provider-conjur/pull/109)

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,10 @@ replace golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a => golang.org/x/c
 
 replace golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 => golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b
 
+replace golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b => golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b
+
+replace golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e => golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b
+
 replace golang.org/x/net v0.0.0-20180530234432-1e491301e022 => golang.org/x/net v0.0.0-20220923203811-8be639271d50
 
 replace golang.org/x/net v0.0.0-20180724234803-3673e40ba225 => golang.org/x/net v0.0.0-20220923203811-8be639271d50
@@ -177,6 +181,8 @@ replace golang.org/x/text v0.3.5 => golang.org/x/text v0.3.7
 replace golang.org/x/text v0.3.6 => golang.org/x/text v0.3.7
 
 replace gopkg.in/yaml.v2 v2.2.2 => gopkg.in/yaml.v2 v2.2.8
+
+replace gopkg.in/yaml.v2 v2.2.3 => gopkg.in/yaml.v2 v2.2.8
 
 replace gopkg.in/yaml.v2 v2.2.4 => gopkg.in/yaml.v2 v2.2.8
 

--- a/go.sum
+++ b/go.sum
@@ -220,7 +220,6 @@ google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome

Prune dependencies with known vulnerabilities from the dep tree. 

### Implemented Changes

- Added replace for 
  - golang.org/x/crypto@v0.0.0-20210421170649-83a5a9bb288b
  - golang.org/x/crypto@v0.0.0-20210616213533-5ff15b29337e
  - gopkg.in/yaml@v2.2.3
