### PR TITLE
Change goreleaser binary name to terraform for darwin arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,8 +17,8 @@ builds:
   ldflags: []
 
 # Apple silicon support
-- id: summon-conjur-arm
-  binary: summon-conjur
+- id: terraform-provider-conjur-arm
+  binary: terraform-provider-conjur_v{{.Version}}
   env:
   - CGO_ENABLED=0
   goos:


### PR DESCRIPTION
### Desired Outcome

Installation of the terraform provider on apple silicon results in an error
```
│ Error: Failed to install provider
│
│ Error while installing cyberark/conjur v0.6.3: provider binary not found: could not find executable file starting with terraform-provider-conjur
```

### Implemented Changes

Change the name of the binary outputted by GoReleaser to terraform-provider-conjur

### Connected Issue/Story

#119 

### Definition of Done

Terraform provider is usable when used from the terraform registry cyberark/conjur

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
